### PR TITLE
Added a new 'time_zone' param for 'time_series' aggregates

### DIFF
--- a/src/main/java/io/orchestrate/client/Aggregate.java
+++ b/src/main/java/io/orchestrate/client/Aggregate.java
@@ -151,7 +151,8 @@ public class Aggregate {
     }
 
     /**
-     * Adds a time-series aggregate to the query for the given field name
+     * Adds a time-series aggregate to the query for the given field name,
+     * with bucket intervals based on the UTC time zone.
      *
      * <p>
      * {@code
@@ -170,6 +171,36 @@ public class Aggregate {
      * @return This request.
      */
     public Aggregate timeSeries(final String fieldName, TimeInterval interval) {
+        return timeSeries(fieldName, interval, null);
+    }
+
+    /**
+     * Adds a time-series aggregate to the query for the given field name,
+     * with bucket intervals based on the designated time zone.
+     * 
+     * Time zone strings must begin with a "+" or "-" character, followed by
+     * four digits representing the hours and minutes of offset, relative to
+     * UTC. For example, Eastern Standard Time (EST) would be represented as
+     * "-0500", since the time in EST is five hours behind that of UTC. 
+     *
+     * <p>
+     * {@code
+     * client.searchCollection("someCollection")
+     *     .aggregate(Aggregate.builder()
+     *         .timeSeries("value.date_of_birth", TimeInterval.MONTH, "-0500")
+     *         .build()
+     *     )
+     *     .get(String.class, "*")
+     *     .get()
+     * }
+     * </p>
+     *
+     * @param fieldName The fully-qualified name of the field to aggregate upon
+     * @param interval The time interval to bucket upon
+     * @param timeZone The time zone to use when computing interval bucket boundaries
+     * @return This request.
+     */
+    public Aggregate timeSeries(final String fieldName, TimeInterval interval, String timeZone) {
         checkNotNull(fieldName, "fieldName");
         checkNotNull(interval, "interval");
         if (b.length() > 0) {
@@ -178,6 +209,10 @@ public class Aggregate {
         b.append(fieldName);
         b.append(":time_series:");
         b.append(interval.toString().toLowerCase());
+        if (timeZone != null) {
+            b.append(':');
+            b.append(timeZone);
+        }
         return this;
     }
 }

--- a/src/main/java/io/orchestrate/client/CollectionSearchResource.java
+++ b/src/main/java/io/orchestrate/client/CollectionSearchResource.java
@@ -99,7 +99,7 @@ public class CollectionSearchResource extends BaseResource {
             query = query.concat("&sort=").concat(sortFields);
         }
         if (aggregateFields != null) {
-            query = query.concat("&aggregate=").concat(aggregateFields);
+            query = query.concat("&aggregate=").concat(client.encode(aggregateFields));
         }
 
         final HttpContent packet = HttpRequestPacket.builder()

--- a/src/main/java/io/orchestrate/client/TimeSeriesAggregateResult.java
+++ b/src/main/java/io/orchestrate/client/TimeSeriesAggregateResult.java
@@ -15,16 +15,20 @@ public class TimeSeriesAggregateResult extends AggregateResult {
 
     private final TimeInterval interval;
 
+    private final String timeZone;
+
     private final List<TimeSeriesBucket> buckets;
 
     TimeSeriesAggregateResult(
         String fieldName,
         long valueCount,
         TimeInterval interval,
+        String timeZone,
         List<TimeSeriesBucket> buckets
     ) {
         super(fieldName, "time_series", valueCount);
         this.interval = interval;
+        this.timeZone = timeZone;
         this.buckets = buckets;
     }
 
@@ -35,6 +39,15 @@ public class TimeSeriesAggregateResult extends AggregateResult {
      */
     public TimeInterval getInterval() {
         return interval;
+    }
+
+    /**
+     * Returns the time-zone offset string for this TimeSeries
+     *
+     * @return The time-zone offset string  object.
+     */
+    public String getTimeZone() {
+        return timeZone;
     }
 
     /**
@@ -56,6 +69,10 @@ public class TimeSeriesAggregateResult extends AggregateResult {
         assert aggregateKind.equals("time_series");
 
         TimeInterval interval = TimeInterval.valueOf(json.get("interval").asText().toUpperCase());
+        String timeZone = null;
+        if (json.has("time_zone")) {
+            timeZone = json.get("time_zone").asText();
+        }
         ArrayNode bucketNodes = (ArrayNode) json.get("buckets");
         List<TimeSeriesBucket> buckets = new ArrayList<TimeSeriesBucket>(bucketNodes.size());
         for (JsonNode bucketNode : bucketNodes) {
@@ -64,7 +81,7 @@ public class TimeSeriesAggregateResult extends AggregateResult {
             buckets.add(new TimeSeriesBucket(bucket, count));
         }
 
-        return new TimeSeriesAggregateResult(fieldName, valueCount, interval, buckets);
+        return new TimeSeriesAggregateResult(fieldName, valueCount, interval, timeZone, buckets);
     }
 
 }

--- a/www/source/querying.html.md
+++ b/www/source/querying.html.md
@@ -668,12 +668,13 @@ SearchResults<DomainObject> results =
               .get(DomainObject.class, luceneQuery)
               .get();
 
-// TimeSeries Aggregate: Count the number new users per day, over the past 30 days
+// TimeSeries Aggregate: Count the number new users per day, over the past 30 days,
+// in my local time zone, "-0800" (Pacific Standard Time is eight hours behind UTC).
 String luceneQuery = "value.signup_date:[2014-11-01 TO 2014-12-01]";
 SearchResults<DomainObject> results =
         client.searchCollection("users")
               .aggregate(Aggregate.builder()
-                  .timeSeries("value.signup_date", TimeInterval.DAY)
+                  .timeSeries("value.signup_date", TimeInterval.DAY, "-0800")
                   .build()
               )
               .get(DomainObject.class, luceneQuery)


### PR DESCRIPTION
Time-series aggregates can now be adjusted to use interval boundaries in your favorite time-zone (instead of the default UTC).