### PR TITLE
Search Events

### DIFF
--- a/src/integTest/java/io/orchestrate/client/itest/EventTest.java
+++ b/src/integTest/java/io/orchestrate/client/itest/EventTest.java
@@ -43,13 +43,13 @@ public final class EventTest extends BaseClientTest {
     public void putEvent(@ForAll(sampleSize=10) final String type) {
         assumeThat(type, not(isEmptyString()));
 
-        final Boolean result =
+        final EventMetadata eventMetadata =
                 client.event(collection(), "key")
                       .type(type)
-                      .put("{}")
+                      .create("{}")
                       .get();
 
-        assertTrue(result);
+        assertNotNull(eventMetadata);
     }
 
     @Theory
@@ -57,24 +57,24 @@ public final class EventTest extends BaseClientTest {
             throws InterruptedException {
         assumeThat(type, not(isEmptyString()));
 
-        final BlockingQueue<Boolean> queue = DataStructures.getLTQInstance(Boolean.class);
+        final BlockingQueue<EventMetadata> queue = DataStructures.getLTQInstance(EventMetadata.class);
         client.event(collection(), "key")
               .type(type)
-              .put("{}")
-              .on(new ResponseAdapter<Boolean>() {
+              .create("{}")
+              .on(new ResponseAdapter<EventMetadata>() {
                   @Override
                   public void onFailure(final Throwable error) {
                       fail(error.getMessage());
                   }
 
                   @Override
-                  public void onSuccess(final Boolean object) {
+                  public void onSuccess(final EventMetadata object) {
                       queue.add(object);
                   }
               });
 
-        final Boolean result = queue.poll(5000, TimeUnit.MILLISECONDS);
-        assertTrue(result);
+        final EventMetadata result = queue.poll(5000, TimeUnit.MILLISECONDS);
+        assertNotNull(result);
     }
 
     @Theory

--- a/src/integTest/java/io/orchestrate/client/itest/LogItem.java
+++ b/src/integTest/java/io/orchestrate/client/itest/LogItem.java
@@ -1,0 +1,30 @@
+package io.orchestrate.client.itest;
+
+public class LogItem {
+    private String source;
+    private String description;
+
+    public LogItem() {
+    }
+
+    public LogItem(String source, String description) {
+        this.source = source;
+        this.description = description;
+    }
+
+    public String getSource() {
+        return source;
+    }
+
+    public void setSource(String source) {
+        this.source = source;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+}

--- a/src/integTest/java/io/orchestrate/client/itest/User.java
+++ b/src/integTest/java/io/orchestrate/client/itest/User.java
@@ -1,0 +1,45 @@
+package io.orchestrate.client.itest;
+
+public class User {
+    private String name;
+    private String description;
+
+    public User(String name, String description) {
+        this.name = name;
+        this.description = description;
+    }
+
+    public User() {
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        User user = (User) o;
+
+        return name.equals(user.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return name.hashCode();
+    }
+}

--- a/src/main/java/io/orchestrate/client/BaseResource.java
+++ b/src/main/java/io/orchestrate/client/BaseResource.java
@@ -61,7 +61,7 @@ abstract class BaseResource {
     }
 
     protected <T> KvObject<T> toKvObject(JsonNode result, Class<T> clazz) throws IOException {
-        return ResponseConverterUtil.jsonToKvObject(mapper, result, clazz);
+        return ResponseConverterUtil.wrapperJsonToKvObject(mapper, result, clazz);
     }
 
     protected <T> KvObject<T> toKvObject(HttpContent response, String collection, String key,

--- a/src/main/java/io/orchestrate/client/Event.java
+++ b/src/main/java/io/orchestrate/client/Event.java
@@ -15,7 +15,7 @@
  */
 package io.orchestrate.client;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -26,46 +26,31 @@ import lombok.ToString;
  * @param <T> The deserializable type for the value of the KV data belonging
  *            to this event.
  */
-@ToString
+@ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
-public class Event<T> extends EventMetadata {
-
-    private final ObjectMapper mapper;
-    /** The value for this event. */
-    private final T value;
-    /** The raw JSON value for this event. */
-    private String rawValue;
+public class Event<T> extends KvObject<T> implements EventMetadata {
+    private final Long timestamp;
+    private final String ordinal;
+    private final String type;
 
     Event(final ObjectMapper mapper, final String collection, final String key, final String type,
-          final Long timestamp, final String ordinal, final String ref, final T value, final String rawValue) {
-        super(collection, key, type, timestamp, ordinal, ref);
-        this.mapper = mapper;
-        this.value = value;
-        // rawValue should not be 'final' b/c it will be lazy created when 'T' is not String
-        this.rawValue = rawValue;
+          final Long timestamp, final String ordinal, final String ref, final T value,
+          final JsonNode valueNode, final String rawValue) {
+        super(collection, key, ref, mapper, value, valueNode, rawValue);
+        this.timestamp = timestamp;
+        this.ordinal = ordinal;
+        this.type = type;
     }
 
-    /**
-     * Returns the KV object for this event.
-     *
-     * @return The KV object for this event.
-     */
-    public final T getValue() {
-        return value;
+    public String getType() {
+        return type;
     }
 
-    /**
-     * Returns the raw JSON value of this event.
-     *
-     * @return The raw JSON value of this event.
-     */
-    public final String getRawValue() {
-        if (rawValue == null && value != null) {
-            try {
-                rawValue = mapper.writeValueAsString(value);
-            } catch (JsonProcessingException ignored) {
-            }
-        }
-        return rawValue;
+    public Long getTimestamp() {
+        return timestamp;
+    }
+
+    public String getOrdinal() {
+        return ordinal;
     }
 }

--- a/src/main/java/io/orchestrate/client/EventMetadata.java
+++ b/src/main/java/io/orchestrate/client/EventMetadata.java
@@ -16,42 +16,25 @@
 
 package io.orchestrate.client;
 
-import lombok.EqualsAndHashCode;
-import lombok.ToString;
-
-@ToString(callSuper = true)
-@EqualsAndHashCode(callSuper = true)
-public class EventMetadata extends KvMetadata {
-    private final Long timestamp;
-    private final String ordinal;
-    private final String type;
-
-    EventMetadata(String collection, String key, String eventType, Long timestamp, String ordinal, String ref) {
-        super(collection, key, ref);
-        this.timestamp = timestamp;
-        this.ordinal = ordinal;
-        this.type = eventType;
-    }
-
-    public String getType() {
-        return type;
-    }
+public interface EventMetadata extends KvMetadata {
+    /**
+     * Returns the type of this event.
+     *
+     * @return The type for this event.
+     */
+    String getType();
 
     /**
      * Returns the timestamp of this event.
      *
      * @return The timestamp for this event.
      */
-    public Long getTimestamp() {
-        return timestamp;
-    }
+    Long getTimestamp();
 
     /**
      * Returns the ordinal of this event.
      *
      * @return The ordinal for this event.
      */
-    public String getOrdinal() {
-        return ordinal;
-    }
+    String getOrdinal();
 }

--- a/src/main/java/io/orchestrate/client/EventResource.java
+++ b/src/main/java/io/orchestrate/client/EventResource.java
@@ -264,7 +264,7 @@ public class EventResource extends BaseResource {
                     final String ref = header.getHeader(Header.ETag)
                             .replace("\"", "")
                             .replace("-gzip", "");
-                    return new EventMetadata(collection, key, type, timestamp, ordinal, ref);
+                    return new Event<Void>(mapper, collection, key, type, timestamp, ordinal, ref, null, null, null);
                 }
                 return null;
             }

--- a/src/main/java/io/orchestrate/client/KvMetadata.java
+++ b/src/main/java/io/orchestrate/client/KvMetadata.java
@@ -21,57 +21,25 @@ import lombok.ToString;
 /**
  * A container for metadata about a KV object.
  */
-@ToString
-@EqualsAndHashCode
-public class KvMetadata {
-
-    /** The collection for this KV metadata. */
-    private final String collection;
-    /** The key for this metadata. */
-    private final String key;
-    /** The version for this metadata. */
-    private final String ref;
-
-    KvMetadata(final String collection, final String key, final String ref) {
-        assert (key != null);
-        assert (key.length() > 0);
-        assert (ref != null);
-        assert (ref.length() > 0);
-
-        this.collection = collection;
-        this.key = key;
-        this.ref = ref;
-    }
-
-    KvMetadata(final KvMetadata metadata) {
-        this(metadata.collection, metadata.key, metadata.ref);
-    }
-
+public interface KvMetadata {
     /**
      * Returns the collection this metadata belongs to.
      *
      * @return The collection of this metadata.
      */
-    public final String getCollection() {
-        return collection;
-    }
+    String getCollection();
 
     /**
      * Returns the key of this metadata.
      *
      * @return The key for this metadata.
      */
-    public final String getKey() {
-        return key;
-    }
+    String getKey();
 
     /**
      * Returns the reference (i.e. "version") of this metadata.
      *
      * @return The reference for this metadata.
      */
-    public final String getRef() {
-        return ref;
-    }
-
+    String getRef();
 }

--- a/src/main/java/io/orchestrate/client/KvResource.java
+++ b/src/main/java/io/orchestrate/client/KvResource.java
@@ -250,7 +250,7 @@ public class KvResource extends BaseResource {
                     final String ref = header.getHeader(Header.ETag)
                             .replace("\"", "")
                             .replace("-gzip", "");
-                    return new KvMetadata(collection, key, ref);
+                    return new KvObject<Void>(collection, key, ref, mapper, null, null, null);
                 }
                 return null;
             }
@@ -287,7 +287,7 @@ public class KvResource extends BaseResource {
                     final String ref = header.getHeader(Header.ETag)
                             .replace("\"", "")
                             .replace("-gzip", "");
-                    return new KvMetadata(collection, key, ref);
+                    return new KvObject<Void>(collection, key, ref, mapper, null, null, null);
                 }
                 return null;
             }
@@ -324,7 +324,7 @@ public class KvResource extends BaseResource {
                     final String ref = header.getHeader(Header.ETag)
                             .replace("\"", "")
                             .replace("-gzip", "");
-                    return new KvMetadata(collection, key, ref);
+                    return new KvObject<Void>(collection, key, ref, mapper, null, null, null);
                 }
                 return null;
             }

--- a/src/main/java/io/orchestrate/client/OrchestrateClient.java
+++ b/src/main/java/io/orchestrate/client/OrchestrateClient.java
@@ -311,7 +311,7 @@ public class OrchestrateClient implements Client {
                     final String ref = header.getHeader(Header.ETag)
                             .replace("\"", "")
                             .replace("-gzip", "");
-                    return new KvMetadata(collection, key, ref);
+                    return new KvObject<Void>(collection, key, ref, builder.mapper.getMapper(), null, null, null);
                 }
                 return null;
             }

--- a/src/main/java/io/orchestrate/client/Result.java
+++ b/src/main/java/io/orchestrate/client/Result.java
@@ -56,6 +56,28 @@ public class Result<T> {
     }
 
     /**
+     * Test whether the result kvObject is an Event.
+     *
+     * @return true if the result is an Event.
+     */
+    public final boolean isEvent() {
+        return kvObject instanceof Event;
+    }
+
+    /**
+     * Get the result kvObject as an Event. If the result is not an Event, an
+     * IllegalStateException will be thrown.
+     *
+     * @return the result kvObject as an Event.
+     */
+    public final Event<T> getEventObject() {
+        if(!isEvent()) {
+            throw new IllegalStateException("Item is not an event.");
+        }
+        return (Event<T>)kvObject;
+    }
+
+    /**
      * Returns the score of this search results.
      *
      * @return The score for this result.

--- a/src/main/java/io/orchestrate/client/SingleEventResource.java
+++ b/src/main/java/io/orchestrate/client/SingleEventResource.java
@@ -241,7 +241,7 @@ public class SingleEventResource extends BaseResource {
                 final String ref = header.getHeader(Header.ETag)
                         .replace("\"", "")
                         .replace("-gzip", "");
-                return new EventMetadata(collection, key, eventType, timestamp, ordinal, ref);
+                return new Event<Void>(mapper, collection, key, eventType, timestamp, ordinal, ref, null, null, null);
             }
             return null;
         }

--- a/www/source/_nav.haml
+++ b/www/source/_nav.haml
@@ -27,6 +27,8 @@
       = link_to 'Events', 'querying.html', :fragment => 'events'
     %li
       = link_to 'Graph', 'querying.html', :fragment => 'graph'
+    %li
+      = link_to 'Async API', 'querying.html', :fragment => 'async-api'
   %h2
     = link_to 'Examples', 'examples.html'
   %ul


### PR DESCRIPTION
Adds support for searching events. This involved refactoring the KvObject hierarchy so that the search resource results can be both KvObjects as well as Events. This should not break users' of the client unless they have made custom subclasses of KvMetadata or EventMetadata.

- change event create tests to use the 'create' method and not the deprecated 'put' method.
- adds POJO tests to serve as an example for how to map responses to java beans
- adds search events tests
- changes many examples to use an example User class vs the DomainObject.
- add docs for event search 