### PR TITLE
Use environment variables instead of gradle properties for tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,8 +161,13 @@ It is recommended to run Gradle with the
 #### Running Integration Tests
 
 To run integration tests you'll need to create an application in the Orchestrate
- [Dashboard](https://dashboard.orchestrate.io/), then put the API key into the
- `gradle.properties` as the value for the property `orchestrate.apiKey`.
+ [Dashboard](https://dashboard.orchestrate.io/), and set the appropriate environment variables:
+
+ ```
+ $ export ORCHESTRATE_API_KEY="Enter API key HERE"
+ # Optionally set a custom endpoint
+ $ export ORCHESTRATE_API_ENDPOINT="https://api.ctl-uc1-a.orchestrate.io"
+ ```
 
 Once you've configured the build system with an API key, it will create the
  `oio-client-integration-tests` collection when you run integration tests with

--- a/build.gradle
+++ b/build.gradle
@@ -97,8 +97,6 @@ task integTest(type: Test, dependsOn: jar) {
     jvmArgs '-ea', '-Djava.awt.headless=true', '-Xms128m', '-Xmx512m', '-XX:MaxPermSize=512m'
 
     systemProperty 'jar.path', jar.archivePath
-    systemProperty 'orchestrate.apiKey', project.getProperty('orchestrate.apiKey')
-    systemProperty 'orchestrate.host', project.getProperty('orchestrate.host')
 }
 
 jar {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,3 @@
-orchestrate.apiKey=
-orchestrate.host=
-
 signing.keyId=
 signing.password=
 signing.secretKeyRingFile=

--- a/src/integTest/java/io/orchestrate/client/itest/BaseClientTest.java
+++ b/src/integTest/java/io/orchestrate/client/itest/BaseClientTest.java
@@ -51,12 +51,17 @@ public abstract class BaseClientTest {
 
     @BeforeClass
     public static void setUpClass() {
-        final String apiKey = System.getProperty("orchestrate.apiKey");
+        final String apiKey = System.getenv("ORCHESTRATE_API_KEY");
         if (apiKey == null || apiKey.length() < 1) {
-            throw new IllegalStateException("Cannot run integration tests, 'apiKey' is blank.");
+            throw new IllegalStateException(
+                    "Cannot run integration tests, the environment variable 'ORCHESTRATE_API_KEY' is blank.");
         }
 
-        URI uri = URI.create(System.getProperty("orchestrate.host", OrchestrateClient.Builder.DEFAULT_HOST));
+        String orchestrate_api_endpoint = System.getenv("ORCHESTRATE_API_ENDPOINT");
+        if (orchestrate_api_endpoint == null || orchestrate_api_endpoint.length() < 1)
+            orchestrate_api_endpoint = OrchestrateClient.Builder.DEFAULT_HOST;
+
+        URI uri = URI.create(orchestrate_api_endpoint);
 
         String host = uri.getScheme()+"://" + uri.getHost();
         int port = uri.getPort();


### PR DESCRIPTION
Use environment variables instead of gradle properties for tests so that developers don't accidentally check in secrets. We should consider this for other gradle properties as we see fit. 

This is now consistent with the development experience for the nodejs client as well:
https://github.com/orchestrate-io/orchestrate.js#running-tests