### PR TITLE
Tshak/fix top values aggregate tests

### DIFF
--- a/src/integTest/java/io/orchestrate/client/itest/AggregateTest.java
+++ b/src/integTest/java/io/orchestrate/client/itest/AggregateTest.java
@@ -44,9 +44,9 @@ public final class AggregateTest extends BaseClientTest {
 
     @Test
     public void testTopValuesAggregate() throws InterruptedException {
-        insertItem("key0", "{`a`:1.0}");
-        insertItem("key1", "{`a`:1.0}");
-        insertItem("key2", "{`a`:1.0}");
+        insertItem("key0", "{`a`:1}");
+        insertItem("key1", "{`a`:1}");
+        insertItem("key2", "{`a`:1}");
         insertItem("key3", "{`a`:`monkey`}");
         insertItem("key4", "{`a`:`monkey`}");
         insertItem("key5", "{`a`:`monkey`}");
@@ -71,9 +71,9 @@ public final class AggregateTest extends BaseClientTest {
 
     @Test
     public void testTopValuesAggregateWithOffsetAndLimit() throws InterruptedException {
-        insertItem("key0", "{`a`:1.0}");
-        insertItem("key1", "{`a`:1.0}");
-        insertItem("key2", "{`a`:1.0}");
+        insertItem("key0", "{`a`:1}");
+        insertItem("key1", "{`a`:1}");
+        insertItem("key2", "{`a`:1}");
         insertItem("key3", "{`a`:`monkey`}");
         insertItem("key4", "{`a`:`monkey`}");
         insertItem("key5", "{`a`:`monkey`}");


### PR DESCRIPTION
`testTopValuesAggregate` and `testTopValuesAggregateWithOffsetAndLimit`were failing occasionally. I narrowed it down to the fact that these tests use mixed data types. My theory is that there is a race condition in our type detection (orc bug?) which would cause the value `1.0` to sometimes be indexed as an integer instead of a double. This would cause the aggregate query to return unexpected results

Consider the following data set:
```js
"key0": {"a":1.0}
"key1": {"a":1.0}
"key2": {"a":1.0}
"key3": {"a":"monkey"}
"key4": {"a":"monkey"}
"key5": {"a":"monkey"}
"key6": {"a":"monkey"}
"key7": {"a":true}
"key8": {"a":null}
"key9": {"a":null}
```
Sometimes an aggregate search would return:
```js
{"value":"monkey","count":4},
{"count":2},
{"value":1,"count":2}, // <-- not expected
{"value":1.0,"count":1},
{"value":false,"count":1}
```

When our test would rightly expect:

```js
{"value":"monkey","count":4},
{"count":2},
{"value":1.0,"count":3}, // <-- expected
{"value":false,"count":1}
```

This is remedied by using replacing `1.0` with `1` in the test data