### PR TITLE
CrossCollectionSearchTest: Don't pass `null` as JSON payload

### DIFF
--- a/src/main/java/io/orchestrate/client/RelationshipResource.java
+++ b/src/main/java/io/orchestrate/client/RelationshipResource.java
@@ -311,7 +311,7 @@ public class RelationshipResource extends BaseResource {
      * @param properties A json object representing the properties of this relationship.
      * @return A prepared create request.
      */
-    public OrchestrateRequest<RelationshipMetadata> put(final String relation, final @NonNull Object properties) {
+    public OrchestrateRequest<RelationshipMetadata> put(final String relation, final Object properties) {
         HttpContent packet = prepareCreateRelationship(relation, properties);
         return new OrchestrateRequest<RelationshipMetadata>(client, packet, new ResponseConverter<RelationshipMetadata>() {
             @Override


### PR DESCRIPTION
The test was throwing the following exception:

```
java.lang.NullPointerException: properties

	at io.orchestrate.client.RelationshipResource.put(RelationshipResource.java:314)
```