### PR TITLE
Bulk Operations

### DIFF
--- a/src/integTest/java/io/orchestrate/client/itest/BlinkData.java
+++ b/src/integTest/java/io/orchestrate/client/itest/BlinkData.java
@@ -1,0 +1,11 @@
+package io.orchestrate.client.itest;
+
+public class BlinkData {
+    public int speed;
+
+    BlinkData(int speed) {
+        this.speed = speed;
+    }
+
+    BlinkData() {}
+}

--- a/src/integTest/java/io/orchestrate/client/itest/BulkTest.java
+++ b/src/integTest/java/io/orchestrate/client/itest/BulkTest.java
@@ -1,0 +1,287 @@
+package io.orchestrate.client.itest;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.orchestrate.client.*;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Iterator;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public final class BulkTest extends BaseClientTest {
+
+    @Test
+    public void insertTwoItems() throws IOException {
+        User user1 = new User("user1", "user1 description");
+        User user2 = new User("user2", "user2 description");
+
+        BulkResponse response = client.bulk()
+                .add(client.kv(collection(), "user1").bulkPut(user1))
+                .add(client.kv(collection(), "user2").bulkPut(user2))
+                .done()
+                .get();
+
+        KvList<User> items = client.listCollection(collection())
+                .get(User.class)
+                .get();
+
+        // Assert items
+
+        assertEquals(2, items.getCount());
+        final Iterator<KvObject<User>> itemsIterator = items.iterator();
+        final KvObject<User> user1Item = itemsIterator.next();
+        assertUser(collection(), "user1", user1, user1Item);
+        final KvObject<User> user2Item = itemsIterator.next();
+        assertUser(collection(), "user2", user2, user2Item);
+
+        // Assert response
+
+        assertNotNull(response);
+        assertEquals(BulkStatus.SUCCESS, response.getStatus());
+        assertEquals(2, response.getSuccessCount());
+        assertEquals(2, response.getResults().size());
+        final Iterator<BulkResult> resultsIterator = response.getResults().iterator();
+        assertBulkSuccessResult(BulkResultStatus.SUCCESS, 0, user1Item, (BulkSuccessResult) resultsIterator.next());
+        assertBulkSuccessResult(BulkResultStatus.SUCCESS, 1, user2Item, (BulkSuccessResult) resultsIterator.next());
+    }
+
+    @Test
+    public void bulkOperation_supportJsonString() throws IOException {
+        BulkResponse response = client.bulk()
+                .add(client.kv(collection(), "user1").bulkPut("{}"))
+                .done()
+                .get();
+
+        assertNotNull(response);
+        assertEquals(BulkStatus.SUCCESS, response.getStatus());
+    }
+
+    @Test
+    public void insertTwoItems_whenOneFails_ReturnsPartialSuccessWithError() throws IOException {
+        User user1 = new User("user1", "user1 description");
+
+        BulkResponse response = client.bulk()
+                .add(client.kv(collection(), "user1").bulkPut(user1))
+                .add(new BulkOperation())
+                .done()
+                .get();
+
+        KvList<User> items = client.listCollection(collection())
+                .get(User.class)
+                .get();
+
+        // Assert items
+
+        assertEquals(1, items.getCount());
+        final Iterator<KvObject<User>> itemsIterator = items.iterator();
+        final KvObject<User> user1Item = itemsIterator.next();
+        assertUser(collection(), "user1", user1, user1Item);
+
+        // Assert response
+
+        assertNotNull(response);
+        assertEquals(BulkStatus.PARTIAL, response.getStatus());
+        assertEquals(1, response.getSuccessCount());
+        assertEquals(2, response.getResults().size());
+        final Iterator<BulkResult> resultsIterator = response.getResults().iterator();
+        assertBulkSuccessResult(BulkResultStatus.SUCCESS, 0, user1Item, (BulkSuccessResult) resultsIterator.next());
+        assertBulkFailureResult_FromEmptyBulkOperation((BulkFailureResult) resultsIterator.next(), 1);
+    }
+
+    @Test
+    public void insertTwoItems_whenBothFails_ReturnsFailureWithErrors() throws IOException {
+        BulkResponse response = client.bulk()
+                .add(new BulkOperation())
+                .add(new BulkOperation())
+                .done()
+                .get();
+
+        assertNotNull(response);
+        assertEquals(BulkStatus.FAILURE, response.getStatus());
+        assertEquals(0, response.getSuccessCount());
+        assertEquals(2, response.getResults().size());
+        final Iterator<BulkResult> resultsIterator = response.getResults().iterator();
+        assertBulkFailureResult_FromEmptyBulkOperation((BulkFailureResult) resultsIterator.next(), 0);
+        assertBulkFailureResult_FromEmptyBulkOperation((BulkFailureResult) resultsIterator.next(), 1);
+    }
+
+    @Test
+    public void insertItemWithTwoEvents() throws IOException {
+        User user1 = new User("user1", "user1 description");
+        Long now = System.currentTimeMillis();
+        Long then = now - 3000;
+
+        BulkResponse response = client.bulk()
+                .add(client.kv(collection(), "user1").bulkPut(user1))
+                .add(client.event(collection(), "user1").type("blinked").timestamp(then).bulkCreate(new BlinkData(1)))
+                .add(client.event(collection(), "user1").type("blinked").timestamp(now).bulkCreate(new BlinkData(2)))
+                .done()
+                .get();
+
+        KvList<User> items = client.listCollection(collection())
+                .get(User.class)
+                .get();
+
+        // Assert items
+
+        assertEquals(1, items.getCount());
+        final Iterator<KvObject<User>> itemsIterator = items.iterator();
+        KvObject<User> user1Item = itemsIterator.next();
+        assertUser(collection(), "user1", user1, user1Item);
+
+        // Assert events
+
+        final EventList<BlinkData> events = client.event(collection(), "user1")
+                .type("blinked")
+                .get(BlinkData.class)
+                .get();
+
+        ArrayList<Event<BlinkData>> eventList = new ArrayList<Event<BlinkData>>();
+        for (Event<BlinkData> event : events.getEvents()) {
+            eventList.add(event);
+        }
+
+        assertEquals(2, eventList.size());
+        assertBlinkEvent(collection(), "user1", "blinked", now, 2, eventList.get(0));
+        assertBlinkEvent(collection(), "user1", "blinked", then, 1, eventList.get(1));
+
+        // Assert response
+
+        assertNotNull(response);
+        assertEquals(BulkStatus.SUCCESS, response.getStatus());
+        assertEquals(3, response.getSuccessCount());
+        assertEquals(3, response.getResults().size());
+        final Iterator<BulkResult> resultsIterator = response.getResults().iterator();
+        assertBulkSuccessResult(BulkResultStatus.SUCCESS, 0, user1Item, (BulkSuccessResult) resultsIterator.next());
+        assertBulkSuccessResult(BulkResultStatus.SUCCESS, 1, eventList.get(1), (BulkSuccessResult) resultsIterator.next());
+        assertBulkSuccessResult(BulkResultStatus.SUCCESS, 2, eventList.get(0), (BulkSuccessResult) resultsIterator.next());
+    }
+
+    @Test
+    public void insertTwoItemsWithTwoRelationships() throws IOException {
+        User user1 = new User("user1", "user1 description");
+        User user2 = new User("user2", "user2 description");
+        JsonNode friendProperties = new ObjectMapper().readTree("{ \"bestFriend\" : true }");
+
+        BulkResponse response = client.bulk()
+                .add(client.kv(collection(), "user1").bulkPut(user1))
+                .add(client.kv(collection(), "user2").bulkPut(user2))
+                .add(client.relationship(collection(), "user1").to(collection(), "user2").bulkPut("friends"))
+                .add(client.relationship(collection(), "user2").to(collection(), "user1").bulkPut("friends", friendProperties))
+                .done()
+                .get();
+
+        // Assert items
+
+        KvList<User> items = client.listCollection(collection())
+                .get(User.class)
+                .get();
+
+        assertEquals(2, items.getCount());
+        final Iterator<KvObject<User>> itemsIterator = items.iterator();
+        final KvObject<User> user1Item = itemsIterator.next();
+        assertUser(collection(), "user1", user1, user1Item);
+        final KvObject<User> user2Item = itemsIterator.next();
+        assertUser(collection(), "user2", user2, user2Item);
+
+        // Assert user1 relationship
+
+        Relationship<JsonNode> user1Friend = client.relationship(collection(), "user1")
+                .get(JsonNode.class, "friends", collection(), "user2")
+                .get();
+
+        assertEquals("user2", user1Friend.getDestinationKey());
+
+        // Assert user2 relationship
+
+        Relationship<JsonNode> user2Friend = client.relationship(collection(), "user2")
+                .get(JsonNode.class, "friends", collection(), "user1")
+                .get();
+
+        assertEquals("user1", user2Friend.getDestinationKey());
+        assertEquals(friendProperties, user2Friend.getValue());
+    }
+
+    @Test
+    public void whenAddIsCalledAfterDone_throw() throws IOException {
+        BulkResource bulkResource = client.bulk();
+        bulkResource.add(client.kv(collection(), "item1").bulkPut("{}"));
+        bulkResource.done();
+
+        Throwable actualException = null;
+
+        try {
+            bulkResource.add(client.kv(collection(), "item2").bulkPut("{}"));
+        } catch (Throwable ex) {
+            actualException = ex;
+        }
+
+        assertNotNull(actualException);
+        assertEquals("Can not add an operation after calling 'done'", actualException.getMessage());
+    }
+
+    private void assertBlinkEvent(
+            String expectedCollection,
+            String expectedKey,
+            String expectedType,
+            Long expectedTimestamp,
+            int expectedBlinkSpeed,
+            Event<BlinkData> actual) {
+        assertEquals(expectedCollection, actual.getCollection());
+        assertEquals(expectedKey, actual.getKey());
+        assertEquals(expectedType, actual.getType());
+        assertEquals(expectedTimestamp, actual.getTimestamp());
+        assertEquals(expectedBlinkSpeed, actual.getValue().speed);
+    }
+
+    private void assertBulkFailureResult_FromEmptyBulkOperation(BulkFailureResult errorResult, int expectedOperationIndex) {
+        assertEquals(expectedOperationIndex, errorResult.getOperationIndex());
+        assertEquals(BulkResultStatus.FAILURE, errorResult.getStatus());
+        assertEquals("The API request is malformed.", errorResult.getError().getMessage());
+        assertEquals("api_bad_request", errorResult.getError().getCode());
+        assertEquals("Can't read bulk operation from malformed JSON",
+                errorResult.getError().getDetails().get("info"));
+    }
+
+    private void assertBulkSuccessResult(
+            BulkResultStatus expectedStatus,
+            int expectedOperationIndex,
+            KvObject expectedItem,
+            BulkSuccessResult actual
+    ) {
+
+        assertEquals(expectedStatus, actual.getStatus());
+        assertEquals(expectedOperationIndex, actual.getOperationIndex());
+        assertItemPath(expectedItem, actual.getItemPath());
+
+        if (actual.getItemPath().getKind() == ItemKind.EVENT) {
+            Event expectedEvent = (Event) expectedItem;
+            EventPath actualEvent = ((BulkSuccessResult<EventPath>) actual).getItemPath();
+            assertEquals(expectedEvent.getOrdinal(), actualEvent.getOrdinal());
+            assertEquals(expectedEvent.getType(), actualEvent.getType());
+            assertEquals(expectedEvent.getTimestamp(), actualEvent.getTimestamp());
+        }
+    }
+
+    private void assertItemPath(KvObject expectedItem, ItemPath actual) {
+        assertEquals(expectedItem.getCollection(), actual.getCollection());
+        assertEquals(expectedItem.getKey(), actual.getKey());
+        assertEquals(expectedItem.getRef(), actual.getRef());
+        assertEquals(expectedItem.getReftime(), actual.getReftime());
+    }
+
+    private void assertUser(
+            String expectedCollection,
+            String expectedKey,
+            User expectedUser,
+            KvObject<User> actual) {
+
+        assertEquals(expectedCollection, actual.getCollection());
+        assertEquals(expectedKey, actual.getKey());
+        assertEquals(expectedUser, actual.getValue());
+    }
+}

--- a/src/main/java/io/orchestrate/client/BulkError.java
+++ b/src/main/java/io/orchestrate/client/BulkError.java
@@ -1,0 +1,35 @@
+package io.orchestrate.client;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * The error for a failed bulk result.
+ */
+public class BulkError {
+    private String message;
+    private String code;
+    private Map<String, String> details;
+
+    /**
+     * @return The error message.
+     */
+    public String getMessage() {
+        return message;
+    }
+
+    /**
+     * @return The error code of an error.
+     */
+    public String getCode() {
+        return code;
+    }
+
+    /**
+     * The details of the error, if any.
+     * @return A key/value pair of detailed error properties.
+     */
+    public Map<String, String> getDetails() {
+        return Collections.unmodifiableMap(details);
+    }
+}

--- a/src/main/java/io/orchestrate/client/BulkFailureResult.java
+++ b/src/main/java/io/orchestrate/client/BulkFailureResult.java
@@ -1,0 +1,22 @@
+package io.orchestrate.client;
+
+/**
+ * The result of a failed bulk operation request.
+ */
+public class BulkFailureResult extends BulkResult {
+    private BulkError error;
+
+    /**
+     * @param operationIndex The operation index of the bulk request.
+     * @param error The error related to the failure.
+     */
+    public BulkFailureResult(int operationIndex, BulkError error) {
+        super(BulkResultStatus.FAILURE, operationIndex);
+        this.error = error;
+    }
+
+    /**
+     * @return The error with details related to the failure.
+     */
+    public BulkError getError() { return error; }
+}

--- a/src/main/java/io/orchestrate/client/BulkOperation.java
+++ b/src/main/java/io/orchestrate/client/BulkOperation.java
@@ -1,0 +1,54 @@
+package io.orchestrate.client;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+/**
+ * Describes a bulk operation.
+ * @see Client#bulk()
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class BulkOperation {
+    @JsonProperty
+    ItemPath path;
+    @JsonProperty
+    private ItemPath source;
+    @JsonProperty
+    private ItemPath destination;
+    @JsonProperty
+    private ItemKind kind;
+    @JsonProperty
+    private String relation;
+    @JsonProperty
+    @JsonSerialize(using = StringToRawJsonSerializer.class)
+    private Object value;
+
+    protected static BulkOperation forKvItem(String collection, String key, Object value) {
+        BulkOperation bulkOperation = new BulkOperation();
+        bulkOperation.path = new ItemPath(collection, key, ItemKind.ITEM);
+        bulkOperation.value = value;
+        return bulkOperation;
+    }
+
+    protected static BulkOperation forEvent(String collection, String key, String type, Long timestamp, Object value) {
+        BulkOperation bulkOperation = new BulkOperation();
+        bulkOperation.path = new EventPath(collection, key, type, timestamp);
+        bulkOperation.value = value;
+        return bulkOperation;
+    }
+
+    protected static BulkOperation forRelationship(String sourceCollection,
+                                         String sourceKey,
+                                         String destCollection,
+                                         String destKey,
+                                         String relation,
+                                         Object properties) {
+        BulkOperation bulkOperation = new BulkOperation();
+        bulkOperation.source = new ItemPath(sourceCollection, sourceKey);
+        bulkOperation.destination = new ItemPath(destCollection, destKey);
+        bulkOperation.relation = relation;
+        bulkOperation.value = properties;
+        return bulkOperation;
+    }
+}

--- a/src/main/java/io/orchestrate/client/BulkResource.java
+++ b/src/main/java/io/orchestrate/client/BulkResource.java
@@ -1,0 +1,151 @@
+package io.orchestrate.client;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.glassfish.grizzly.http.*;
+import org.glassfish.grizzly.memory.ByteBufferWrapper;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * The resource for the Bulk features in the Orchestrate API.
+ */
+public class BulkResource extends BaseResource {
+    final List<BulkOperation> bulkOperations;
+    private final OrchestrateClient client;
+    private Boolean isDone = false;
+
+    public BulkResource(OrchestrateClient client, JacksonMapper jacksonMapper) {
+        super(client, jacksonMapper);
+        this.client = client;
+        bulkOperations = Collections.synchronizedList(new ArrayList<BulkOperation>());
+    }
+
+    /**
+     * Adds an operation to the list of operations to send in bulk. This API is not typically called by a consumer.
+     * It is recommended that you use the associated bulk methods provided by {@link Client#bulk()}.
+     *
+     * @param bulkOperation The bulk operation.
+     * @return This bulk resource.
+     *
+     * @see Client#bulk()
+     */
+    public BulkResource add(BulkOperation bulkOperation) {
+        if (isDone)
+            throw new IllegalStateException("Can not add an operation after calling 'done'");
+
+        bulkOperations.add(bulkOperation);
+        return this;
+    }
+
+    /**
+     * Indicates that you are done adding bulk operations and prepares a bulk request.
+     *
+     * @return The prepared bulk request.
+     * @throws IOException
+     */
+    public OrchestrateRequest<BulkResponse> done() throws IOException {
+        isDone = true;
+        ByteArrayOutputStream requestStream = new ByteArrayOutputStream();
+        for (BulkOperation bulkOperation : this.bulkOperations) {
+            requestStream.write(toJsonBytes(bulkOperation));
+        }
+
+        final String uri = client.uri();
+
+        final HttpRequestPacket.Builder httpHeaderBuilder = HttpRequestPacket.builder()
+                .method(Method.POST)
+                .contentType("application/orchestrate-export-stream+json")
+                .uri(uri);
+
+        httpHeaderBuilder.contentLength(requestStream.size());
+
+        final HttpContent packet = httpHeaderBuilder.build()
+                .httpContentBuilder()
+                .content(new ByteBufferWrapper(ByteBuffer.wrap(requestStream.toByteArray())))
+                .build();
+
+        return new OrchestrateRequest<BulkResponse>(client, packet, new ResponseConverter<BulkResponse>() {
+            @Override
+            public BulkResponse from(final HttpContent response) throws IOException {
+                final HttpHeader header = response.getHttpHeader();
+                final int status = ((HttpResponsePacket) header).getStatus();
+
+                // Note: Even failed bulk requests return as a 200 with failure information
+                if (status == 200)
+                    return createResponse(response);
+                else
+                    // TODO Add basic response details to non 200 responses
+                    // Returning `null` is consistent with the rest of the client, but I think
+                    // this is suboptimal.
+                    return null;
+            }
+        });
+    }
+
+    private BulkResponse createResponse(HttpContent httpResponse) throws IOException {
+        final JsonNode jsonNode = toJsonNode(httpResponse);
+        BulkResponse bulkResponse = new BulkResponse(
+                BulkStatus.fromJson(jsonNode.get("status").asText()),
+                jsonNode.get("success_count").asInt());
+
+        addBulkResultsToBulkResponse(jsonNode, bulkResponse);
+
+        return bulkResponse;
+    }
+
+    private void addBulkResultsToBulkResponse(JsonNode jsonNode, BulkResponse bulkResponse) throws IOException {
+        final Iterator<JsonNode> results = jsonNode.get("results").elements();
+        while (results.hasNext()) {
+            JsonNode itemNode = results.next();
+            BulkResultStatus status = BulkResultStatus.fromJson(itemNode.get("status").asText());
+            if (status == BulkResultStatus.SUCCESS) {
+                bulkResponse.results.add(createBulkSuccessResult(itemNode));
+            } else {
+                bulkResponse.results.add(createBulkErrorResult(itemNode));
+            }
+        }
+    }
+
+    private BulkFailureResult createBulkErrorResult(JsonNode errorNode) throws IOException {
+        return new BulkFailureResult(
+                errorNode.get("operation_index").asInt(),
+                ResponseConverterUtil.jsonToDomainObject(mapper, errorNode.get("error"), BulkError.class));
+    }
+
+    private BulkSuccessResult createBulkSuccessResult(JsonNode successNode) throws IOException {
+        BulkSuccessResult bulkSuccessResult;
+        final int operation_index = successNode.get("operation_index").asInt();
+        if (successNode.has("item")) {
+            bulkSuccessResult = createBulkSuccessResultWithItem(successNode.get("item"), operation_index);
+        } else {
+            bulkSuccessResult = new BulkSuccessResult<ItemPath>(operation_index, null);
+        }
+
+        return bulkSuccessResult;
+    }
+
+    private BulkSuccessResult createBulkSuccessResultWithItem(JsonNode itemNode, int operation_index) throws IOException {
+        BulkSuccessResult bulkSuccessResult;
+        JsonNode pathNode = itemNode.get("path");
+        ItemKind kind = ResponseConverterUtil.parseItemKind(pathNode.get("kind").asText());
+
+        if (kind == ItemKind.ITEM) {
+            bulkSuccessResult = new BulkSuccessResult<ItemPath>(
+                    operation_index,
+                    ResponseConverterUtil.jsonToDomainObject(mapper, pathNode, ItemPath.class));
+        } else if (kind == ItemKind.EVENT) {
+            bulkSuccessResult = new BulkSuccessResult<EventPath>(
+                    operation_index,
+                    ResponseConverterUtil.jsonToDomainObject(mapper, pathNode, EventPath.class));
+        } else {
+            throw new IllegalStateException(String.format("Unable to handle bulk result with kind: '%s'", kind));
+        }
+        return bulkSuccessResult;
+    }
+}

--- a/src/main/java/io/orchestrate/client/BulkResponse.java
+++ b/src/main/java/io/orchestrate/client/BulkResponse.java
@@ -1,0 +1,43 @@
+package io.orchestrate.client;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * The response from a bulk request.
+ */
+public class BulkResponse {
+    private final BulkStatus status;
+    private final int successCount;
+    protected final ArrayList<BulkResult> results;
+
+    public BulkResponse(BulkStatus status, int successCount) {
+        this.status = status;
+        this.successCount = successCount;
+        results = new ArrayList<BulkResult>();
+    }
+
+    /**
+     * Returns a status indicating whether or not the bulk request was successful.
+     * @return {@link BulkStatus#SUCCESS} if all operations succeed, {@link BulkStatus#PARTIAL} if some operations
+     * succeed,and {@link BulkStatus#FAILURE} if all operations fail.
+     */
+    public BulkStatus getStatus() {
+        return status;
+    }
+
+    /**
+     * @return The number of bulk operations that were successful.
+     */
+    public int getSuccessCount() {
+        return successCount;
+    }
+
+    /**
+     * @return The results of each bulk operation.
+     */
+    public List<BulkResult> getResults() {
+        return Collections.unmodifiableList(results);
+    }
+}

--- a/src/main/java/io/orchestrate/client/BulkResult.java
+++ b/src/main/java/io/orchestrate/client/BulkResult.java
@@ -1,0 +1,35 @@
+package io.orchestrate.client;
+
+/**
+ * The result of a bulk operation.
+ *
+ * @see BulkSuccessResult
+ * @see BulkFailureResult
+ */
+public class BulkResult {
+    private BulkResultStatus status;
+    private int operationIndex;
+
+    public BulkResult(BulkResultStatus status, int operationIndex) {
+        this.status = status;
+        this.operationIndex = operationIndex;
+    }
+
+    /**
+     * The status of the bulk operation.
+     * @return {@link BulkResultStatus#SUCCESS} if the operation succeeded. Otherwise, {@link BulkResultStatus#FAILURE}.
+     *
+     * @see BulkSuccessResult
+     * @see BulkFailureResult
+     */
+    public BulkResultStatus getStatus() {
+        return status;
+    }
+
+    /**
+     * @return The operation index of the bulk request.
+     */
+    public int getOperationIndex() {
+        return operationIndex;
+    }
+}

--- a/src/main/java/io/orchestrate/client/BulkResultStatus.java
+++ b/src/main/java/io/orchestrate/client/BulkResultStatus.java
@@ -1,0 +1,13 @@
+package io.orchestrate.client;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+public enum BulkResultStatus {
+    SUCCESS,
+    FAILURE;
+
+    @JsonCreator
+    public static BulkResultStatus fromJson(String status) {
+        return BulkResultStatus.valueOf(status.toUpperCase());
+    }
+}

--- a/src/main/java/io/orchestrate/client/BulkStatus.java
+++ b/src/main/java/io/orchestrate/client/BulkStatus.java
@@ -1,0 +1,14 @@
+package io.orchestrate.client;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+public enum BulkStatus {
+    SUCCESS,
+    FAILURE,
+    PARTIAL;
+
+    @JsonCreator
+    public static BulkStatus fromJson(String name) {
+        return BulkStatus.valueOf(name.toUpperCase());
+    }
+}

--- a/src/main/java/io/orchestrate/client/BulkSuccessResult.java
+++ b/src/main/java/io/orchestrate/client/BulkSuccessResult.java
@@ -1,0 +1,24 @@
+package io.orchestrate.client;
+
+/**
+ * The result of a successful bulk operation request.
+ *
+ * @param <TItemPath> Provides additional details. {@link ItemPath} represents a KV item and
+ * {@link EventPath} represents an event.
+ */
+public class BulkSuccessResult<TItemPath extends ItemPath> extends BulkResult {
+    private final TItemPath itemPath;
+
+    public BulkSuccessResult(int operationIndex, TItemPath itemPath) {
+        super(BulkResultStatus.SUCCESS, operationIndex);
+
+        this.itemPath = itemPath;
+    }
+
+    /**
+     * @return Provides additional details about the bulk operation if available.
+     */
+    public TItemPath getItemPath() {
+        return itemPath;
+    }
+}

--- a/src/main/java/io/orchestrate/client/Client.java
+++ b/src/main/java/io/orchestrate/client/Client.java
@@ -23,6 +23,25 @@ import java.io.IOException;
 public interface Client {
 
     /**
+     * The resource for the bulk features in the Orchestrate API.
+     *
+     * <p>Usage:</p>
+     * <pre>
+     * {@code
+     * client.bulk()
+     *   .add(client.kv("someCollection", "key1").bulkPut(obj))
+     *   .add(client.event("someCollection", "key1").type("someEvent").bulkCreate(obj))
+     *   .add(client.relationship("someCollection", "key1").to("someCollection", "key2").bulkPut("someRelationship"))
+     *   .add(...)
+     *   .done();
+     * }
+     * </pre>
+     *
+     * @return The bulk resource.
+     */
+    public BulkResource bulk();
+
+    /**
      * Stops the thread pool and closes all connections in use by all the
      * operations.
      *

--- a/src/main/java/io/orchestrate/client/EventPath.java
+++ b/src/main/java/io/orchestrate/client/EventPath.java
@@ -1,0 +1,42 @@
+package io.orchestrate.client;
+
+import com.fasterxml.jackson.annotation.*;
+import lombok.NonNull;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class EventPath extends ItemPath {
+    @JsonProperty
+    private String type;
+    @JsonProperty
+    private Long timestamp;
+    @JsonProperty
+    private String ordinal;
+    @JsonProperty
+    private String ordinal_str;
+
+    protected EventPath(
+            @NonNull String collection,
+            @NonNull String key,
+            @NonNull String type,
+            @NonNull Long timestamp) {
+        super(collection, key, ItemKind.EVENT);
+
+        this.type = type;
+        this.timestamp = timestamp;
+    }
+
+    // Used for JSON serialization
+    protected EventPath() {}
+
+    public String getType() {
+        return type;
+    }
+
+    public Long getTimestamp() {
+        return timestamp;
+    }
+
+    public String getOrdinal() {
+        return ordinal;
+    }
+}

--- a/src/main/java/io/orchestrate/client/EventResource.java
+++ b/src/main/java/io/orchestrate/client/EventResource.java
@@ -68,6 +68,19 @@ public class EventResource extends BaseResource {
     }
 
     /**
+     * Add an event to a key in the Orchestrate service as part of a bulk operation.
+     *
+     * @param value The object to store as the event.
+     * @return The bulk operation
+     *
+     * @see #create(Object)
+     * @see Client#bulk()
+     */
+    public BulkOperation bulkCreate(final @NonNull Object value) {
+        return BulkOperation.forEvent(this.collection, this.key, this.type, this.timestamp, value);
+    }
+
+    /**
      * Fetch events for a key in the Orchestrate service.
      *
      * <p>Usage:</p>

--- a/src/main/java/io/orchestrate/client/ItemPath.java
+++ b/src/main/java/io/orchestrate/client/ItemPath.java
@@ -1,0 +1,37 @@
+package io.orchestrate.client;
+
+import com.fasterxml.jackson.annotation.*;
+import lombok.NonNull;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ItemPath {
+    @JsonProperty
+    private String collection;
+    @JsonProperty
+    private String key;
+    @JsonProperty
+    private ItemKind kind;
+    @JsonProperty
+    private String ref;
+    @JsonProperty
+    private Long reftime;
+
+    public ItemPath(@NonNull String collection, @NonNull String key) {
+        this(collection, key, null);
+    }
+
+    public ItemPath(@NonNull String collection, @NonNull String key, ItemKind kind) {
+        this.collection = collection;
+        this.key = key;
+        this.kind = kind;
+    }
+
+    // Used for JSON serialization
+    protected ItemPath() {}
+
+    public String getCollection() { return collection; }
+    public String getKey() { return key; }
+    public ItemKind getKind() { return kind; }
+    public String getRef() { return ref; }
+    public Long getReftime() { return reftime; }
+}

--- a/src/main/java/io/orchestrate/client/KvResource.java
+++ b/src/main/java/io/orchestrate/client/KvResource.java
@@ -61,6 +61,30 @@ public class KvResource extends BaseResource {
     }
 
     /**
+     * Store an object by key to the Orchestrate service as part of a bulk operation.
+     *
+     * <p>Usage:</p>
+     * <pre>
+     * {@code
+     * client.bulk()
+     *   .add(client.kv("someCollection", "key1").bulkPut(obj))
+     *   .add(client.kv("someCollection", "key2").bulkPut(obj))
+     *   .add(...)
+     *   .done();
+     * }
+     * </pre>
+     *
+     * @param value The object to store.
+     * @return The bulk operation.
+     *
+     * @see #put(Object)
+     * @see Client#bulk()
+     */
+    public BulkOperation bulkPut(final @NonNull Object value) {
+        return BulkOperation.forKvItem(collection, key, value);
+    }
+
+    /**
      * {@link #delete(boolean)}.
      * @return The prepared delete request.
      */

--- a/src/main/java/io/orchestrate/client/OrchestrateClient.java
+++ b/src/main/java/io/orchestrate/client/OrchestrateClient.java
@@ -188,6 +188,12 @@ public class OrchestrateClient implements Client {
 
     /** {@inheritDoc} */
     @Override
+    public BulkResource bulk() {
+        return new BulkResource(this, builder.mapper);
+    }
+
+    /** {@inheritDoc} */
+    @Override
     public void close() throws IOException {
         if (transport != null && !transport.isStopped()) {
             transport.shutdownNow();

--- a/src/main/java/io/orchestrate/client/RelationshipResource.java
+++ b/src/main/java/io/orchestrate/client/RelationshipResource.java
@@ -76,6 +76,51 @@ public class RelationshipResource extends BaseResource {
     }
 
     /**
+     * Store a relationship between two objects in the Orchestrate service as part of a bulk operation.
+     *
+     * <p>Usage:</p>
+     * <pre>
+     * {@code
+     * client.bulk()
+     *   .add(client.relationship("someCollection", "key1").to("someCollection", "key2").bulkPut("someRelationship"))
+     *   .add(...)
+     *   .done();
+     * }
+     * </pre>
+     * @param relation The name of the relationship.
+     * @return The bulk operation.
+     *
+     * @see #put(String)
+     * @see Client#bulk()
+     */
+    public BulkOperation bulkPut(final String relation) {
+        return BulkOperation.forRelationship(sourceCollection, sourceKey, destCollection, destKey, relation, null);
+    }
+
+    /**
+     * Store a relationship between two objects in the Orchestrate service as part of a bulk operation.
+     *
+     * <p>Usage:</p>
+     * <pre>
+     * {@code
+     * client.bulk()
+     *   .add(client.relationship("someCollection", "key1").to("someCollection", "key2").bulkPut("someRelationship", obj))
+     *   .add(...)
+     *   .done();
+     * }
+     * </pre>
+     * @param relation The name of the relationship.
+     * @param properties A json object representing the properties of this relationship.
+     * @return the bulk operation.
+     *
+     * @see #put(String, Object)
+     * @see Client#bulk()
+     */
+    public BulkOperation bulkPut(final String relation, final Object properties) {
+        return BulkOperation.forRelationship(sourceCollection, sourceKey, destCollection, destKey, relation, properties);
+    }
+
+    /**
      * Equivalent to {@code this.ifAbsent(Boolean.TRUE)}.
      *
      * @return This RelationshipResource.
@@ -188,7 +233,7 @@ public class RelationshipResource extends BaseResource {
      * <p>Usage:</p>
      * <pre>
      * {@code
-     * RelationList<String> relatedObjects =
+     * RelationshipList<String> relatedObjects =
      *         client.relationship("someCollection", "someKey")
      *               .get(String.class, "someRelation")
      *               .get();

--- a/src/main/java/io/orchestrate/client/ResponseConverterUtil.java
+++ b/src/main/java/io/orchestrate/client/ResponseConverterUtil.java
@@ -25,6 +25,15 @@ import java.io.IOException;
  * Orchestrate.
  */
 final class ResponseConverterUtil {
+    static ItemKind parseItemKind(String kindText) {
+        ItemKind kind;
+        try {
+            kind = ItemKind.fromJson(kindText);
+        } catch (Exception e) {
+            throw new IllegalStateException(String.format("Unknown kind '%s', cannot parse response.", kindText));
+        }
+        return kind;
+    }
 
     static <T> KvObject<T> wrapperJsonToKvObject(
             final ObjectMapper mapper, final JsonNode jsonNode, final Class<T> clazz)
@@ -37,14 +46,7 @@ final class ResponseConverterUtil {
         // {"collection":"coll","key":"aKey","ref":"someRef"}
         final JsonNode path = jsonNode.get("path");
 
-        String kindText = path.get("kind").asText();
-        ItemKind kind = null;
-        try {
-            kind = ItemKind.fromJson(kindText);
-        } catch (Exception e) {
-            throw new IllegalStateException(String.format("Unknown kind '%s', cannot parse as a KvObject.", kindText));
-        }
-
+        ItemKind kind = parseItemKind(path.get("kind").asText());
         if (kind.equals(ItemKind.EVENT)) {
             return wrapperJsonToEvent(mapper, jsonNode, clazz);
         } else if (kind.equals(ItemKind.RELATIONSHIP)) {

--- a/src/main/java/io/orchestrate/client/StringToRawJsonSerializer.java
+++ b/src/main/java/io/orchestrate/client/StringToRawJsonSerializer.java
@@ -1,0 +1,18 @@
+package io.orchestrate.client;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import java.io.IOException;
+
+public class StringToRawJsonSerializer extends JsonSerializer<Object> {
+    @Override
+    public void serialize(Object value, JsonGenerator jgen, SerializerProvider provider) throws IOException, JsonProcessingException {
+        if (value instanceof String) {
+            jgen.writeRawValue((String)value);
+        } else {
+            jgen.writeObject(value);
+        }
+    }
+}


### PR DESCRIPTION
This is a WIP for getting early feedback for adding basic KV support to to bulk operations. There is no plan to merge this PR in its current form to `master`.

Basic usage:

```
       BulkResponse response = client.bulk()
                .add(client.kv(collection(), "user1").bulkPut(user1))
                .add(client.kv(collection(), "user2").bulkPut(user2))
                .done()
                .get();
```

Refer to `BulkTest` for more detailed usage.

TODO:

- [x] Model bulk results similar to orchestrate's `StoragePath` class hierarchy. 
- [x] Support Error responses
- [x] Fix access modifiers on fields for many `Bulk*` classes and introduce public getters
- [x] Remove `null` values from bulk request (regressed during `ItemPath` refactoring)
- [x] Support value: `"{}"` as empty object (?) _Note: I really don't like this but it'd be consistent with our existing API_
- [x] JavaDocs
- [x] API docs
- [x] Clean up TODO's :)
- [x] Throw if `BulkResource.add` is called after `BulkResource.done` is called?