### PR TITLE
Parse reftime into the KvObject.

### DIFF
--- a/src/integTest/java/io/orchestrate/client/itest/KvTest.java
+++ b/src/integTest/java/io/orchestrate/client/itest/KvTest.java
@@ -161,6 +161,7 @@ public final class KvTest extends BaseClientTest {
         assertEquals("bar", resultJson.get("foo").asText());
         assertFalse(resultJson.has("bing"));
         assertFalse(resultJson.has("zip"));
+
     }
 
     @Test

--- a/src/main/java/io/orchestrate/client/BaseResource.java
+++ b/src/main/java/io/orchestrate/client/BaseResource.java
@@ -30,7 +30,6 @@ import java.net.URI;
 import java.nio.charset.Charset;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Date;
 import java.util.Locale;
 
 /**
@@ -45,7 +44,7 @@ abstract class BaseResource {
 
     protected final JacksonMapper jacksonMapper;
     private static final Charset UTF8 = Charset.forName("UTF-8");
-    private static final SimpleDateFormat lastModifiedFormat = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.US);
+    private static final SimpleDateFormat LAST_MODIFIED_FORMAT = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.US);
 
     BaseResource(final OrchestrateClient client, final JacksonMapper mapper) {
         assert (client != null);
@@ -91,7 +90,7 @@ abstract class BaseResource {
                 .replaceFirst("-gzip$", "");
         Long reftime = null;
         try {
-            reftime = lastModifiedFormat.parse(response.getHttpHeader().getHeader(Header.LastModified)).getTime();
+            reftime = LAST_MODIFIED_FORMAT.parse(response.getHttpHeader().getHeader(Header.LastModified)).getTime();
         } catch (ParseException e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/io/orchestrate/client/KvMetadata.java
+++ b/src/main/java/io/orchestrate/client/KvMetadata.java
@@ -43,8 +43,7 @@ public interface KvMetadata {
     /**
      * Returns the reftime of this metadata. This may be null if reftime is not available (for example, if the
      * KvMetadata is parsed from a Location header after a CREATE request where the refime is not presented). Reftime
-     * is only present on search results or object listing queries. It is NOT present on create responses or individual
-     * GET requests.
+     * is only present on search results or object listing queries. It is NOT present on create responses.
      * @return The reftime for this metadata.
      */
     Long getReftime();

--- a/src/main/java/io/orchestrate/client/ResponseConverterUtil.java
+++ b/src/main/java/io/orchestrate/client/ResponseConverterUtil.java
@@ -93,7 +93,7 @@ final class ResponseConverterUtil {
     }
 
     public static <T> KvObject<T> jsonToKvObject(ObjectMapper mapper, String rawValue, Class<T> clazz,
-                                                 String collection, String key, String ref) throws IOException {
+                                                 String collection, String key, String ref, long reftime) throws IOException {
         assert (mapper != null);
         assert (clazz != null);
 
@@ -104,7 +104,7 @@ final class ResponseConverterUtil {
 
         final T value = jsonToDomainObject(mapper, valueNode, rawValue, clazz);
 
-        return new KvObject<T>(collection, key, ref, null, mapper, value, valueNode, rawValue);
+        return new KvObject<T>(collection, key, ref, reftime, mapper, value, valueNode, rawValue);
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
Get KvObject by Key
```
HTTP/1.1 200 OK
x-orchestrate-req-id: e1fd2cd0-133c-11e6-9dc4-000c298abef8
last-modified: Thu, 05 May 2016 10:40:17 GMT
etag: "4682e4bfe3692117-gzip"
content-type: application/json
```
Parse last-modified into KvObject.
